### PR TITLE
fix: Possible shell escape sequence injection vulnerability eRubY

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
     puma (5.6.2)
       nio4r (~> 2.0)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.9)
     rack-protection (2.1.0)
       rack
     rack-test (1.1.0)


### PR DESCRIPTION

There is a possible shell escape sequence injection vulnerability in the `Lint` and `CommonLogger` components of E-CommerceRubY via Rack.

```dif
        ## * The <tt>REQUEST_METHOD</tt> must be a valid token.
        unless env[REQUEST_METHOD] =~ /\A[0-9A-Za-z!\#$%&'*+.^_`|~-]+\z/
-          raise LintError, "REQUEST_METHOD unknown: #{env[REQUEST_METHOD]}"
        end

        ## * The <tt>SCRIPT_NAME</tt>, if non-empty, must start with <tt>/</tt>
```